### PR TITLE
Enable static frontend without Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ Aplicación web completa con backend FastAPI y frontend HTML/CSS/JavaScript, con
 ### Windows
 - Python 3.8 o superior
 - pip (incluido con Python)
-- Node.js 16 o superior
-- npm (incluido con Node.js)
 
 ### Linux
 - Python 3.8 o superior
 - pip3
-- Node.js 16 o superior
-- npm (incluido con Node.js)
 
 ## 🚀 Instalación y Uso
 
@@ -136,10 +132,10 @@ Para distribuir la aplicación a usuarios finales:
    - La aplicación detectará automáticamente las dependencias necesarias.
 
 3. **Requisitos para el usuario final**
-   - Node.js y npm instalados en el sistema.
+   - Solo Python instalado. Node.js es opcional.
 
 4. **Notas**
-   - Si quieres un ejecutable que no dependa de Node, deberías empaquetar el build estático (`npm run build`) y servirlo con un mini-servidor Python.
+   - El frontend puede servirse directamente con `python -m http.server` desde la carpeta `frontend`.
 
 ## 📁 Estructura del Proyecto
 
@@ -214,6 +210,7 @@ Este error ocurre en sistemas Linux modernos. **Solución:**
    ```
 
 ### Error: "Node.js no está instalado"
+Si necesitas funcionalidades de Vite, instala Node.js:
 - **Windows**: Descarga e instala Node.js desde [nodejs.org](https://nodejs.org)
 - **Linux**: `sudo apt install nodejs npm`
 
@@ -251,10 +248,9 @@ cd backend
 pip install -r requirements.txt
 python -m uvicorn app.main:app --reload
 
-# Frontend (con Vite)
+# Frontend estático
 cd frontend
-npm install
-npm run dev
+python -m http.server 5173
 
 # O usar el script completo
 python run_app.py

--- a/build.py
+++ b/build.py
@@ -57,9 +57,8 @@ def install_dependencies():
     # Instalar dependencias del frontend si está habilitado
     if config.is_frontend_mode():
         if not check_node_npm():
-            print("❌ Error: Node.js y npm no están instalados")
-            print("💡 Instala Node.js desde https://nodejs.org")
-            return False
+            print("⚠️ Node.js no encontrado. Se omitirá la instalación del frontend.")
+            return True
         
         frontend_dir = Path(__file__).parent / "frontend"
         if frontend_dir.exists():
@@ -301,20 +300,21 @@ def main():
     # Mostrar configuración
     config.print_config()
     
-    # Verificar Node.js si se necesita frontend
-    if config.is_frontend_mode():
-        if not check_node_npm():
-            print("❌ Error: Node.js y npm no están instalados")
-            print("💡 Instala Node.js desde https://nodejs.org")
-            sys.exit(1)
+    # Verificar Node.js solo si se compilará el frontend
+    if config.is_frontend_mode() and check_node_npm():
+        node_available = True
+    else:
+        node_available = False
+        if config.is_frontend_mode():
+            print("⚠️ Node.js no encontrado. Se omitirá la compilación del frontend")
     
     # Instalar dependencias
     if not install_dependencies():
         print("❌ Error instalando dependencias")
         sys.exit(1)
     
-    # Construir frontend si está habilitado
-    if config.is_frontend_mode():
+    # Construir frontend solo si Node está disponible
+    if config.is_frontend_mode() and node_available:
         if not build_frontend():
             print("❌ Error construyendo frontend")
             sys.exit(1)

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@ backend:
 frontend:
   port: 5173
   host: localhost
-  hot_reload: true
+  hot_reload: false
   open_browser: true
 build:
   mode: development

--- a/install.py
+++ b/install.py
@@ -278,19 +278,18 @@ def install_dependencies():
         if mode in ['frontend', 'full']:
             frontend_dir = Path(__file__).parent / "frontend"
             package_json = frontend_dir / "package.json"
-            
+
             if package_json.exists():
-                print("🎨 Frontend detectado, instalando dependencias de Node.js...")
-                if not check_node_npm():
-                    print("❌ Node.js y/o npm no están instalados. No se pueden instalar las dependencias del frontend.")
-                    print("💡 Instala Node.js desde https://nodejs.org")
-                else:
+                print("🎨 Frontend detectado")
+                if check_node_npm():
                     try:
                         shell = platform.system() == "Windows"
                         subprocess.check_call(["npm", "install"], cwd=frontend_dir, shell=shell)
                         print("✅ Dependencias del frontend (npm) instaladas")
                     except subprocess.CalledProcessError as e:
                         print(f"❌ Error instalando dependencias del frontend: {e}")
+                else:
+                    print("⚠️ Node.js no encontrado. Saltando dependencias del frontend")
             else:
                 print("ℹ️ No se encontró frontend/package.json. Saltando dependencias del frontend.")
         
@@ -433,9 +432,7 @@ def main():
         if check_node_npm():
             print("✅ Node.js y npm detectados")
         else:
-            print("⚠️ Node.js no detectado - el frontend no funcionará")
-            print("💡 Instala Node.js desde https://nodejs.org")
-            print("   O en Linux: sudo apt install nodejs npm")
+            print("⚠️ Node.js no detectado. El frontend se servirá de forma estática")
         print()
     
     # Instalar dependencias


### PR DESCRIPTION
## Summary
- serve frontend statically when Node is unavailable
- disable hot reload by default in `config.yml`
- avoid stopping if Node.js is missing during install/build
- clarify Node is optional in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688993f728fc8320ac50eb531b7502e0