### PR TITLE
Update references to backend main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ cubo_app/
 │   ├── app/
 │   │   ├── __init__.py
 │   │   ├── main.py          # API FastAPI
-│   │   └── server.py        # Servidor backend
+│   ├── main.py          # Servidor backend
 │   ├── requirements.txt     # Dependencias Python
 │   └── dist/               # Ejecutable generado
 ├── frontend/
@@ -222,7 +222,7 @@ Si necesitas funcionalidades de Vite, instala Node.js:
 - **Linux**: `sudo apt install python3-venv`
 
 ### Error: "Puerto 8000 en uso"
-- Cambia el puerto en `backend/app/server.py` línea 35
+- Cambia el puerto en `backend/main.py` línea 35
 - O detén otros servicios que usen el puerto 8000
 
 ### Error: "No se pudo abrir el navegador"

--- a/test_quick.py
+++ b/test_quick.py
@@ -34,7 +34,7 @@ def check_venv():
 def check_backend_files():
     """Verifica que los archivos del backend existan"""
     backend_dir = Path(__file__).parent / "backend"
-    server_script = backend_dir / "app" / "server.py"
+    server_script = backend_dir / "main.py"
     
     if not backend_dir.exists():
         print("❌ Directorio backend no encontrado")
@@ -62,7 +62,7 @@ def test_server():
     
     # Iniciar servidor
     backend_dir = Path(__file__).parent / "backend"
-    server_script = backend_dir / "app" / "server.py"
+    server_script = backend_dir / "main.py"
     
     try:
         # Cambiar al directorio del backend


### PR DESCRIPTION
## Summary
- fix documentation about server script path
- adapt `test_quick.py` to look for `backend/main.py`

## Testing
- `python test_quick.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6889a0edf1a4832094c1c6dc694ce865