### PR TITLE
Fix uvicorn start target

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -57,7 +57,7 @@ def run_server(host="0.0.0.0", port=8000):
     reload = config.backend_reload if config.backend_reload else False
     debug = "debug" if config.backend_debug else "info"
 
-    uvicorn.run("backend.app.server:app", host=server_host, port=server_port, reload=reload, log_level=debug)
+    uvicorn.run("backend.main:app", host=server_host, port=server_port, reload=reload, log_level=debug)
 
 if __name__ == "__main__":
     run_server() 


### PR DESCRIPTION
## Summary
- correct target module in `uvicorn.run` call

## Testing
- `python backend/main.py` *(fails: No module named 'config')*

------
https://chatgpt.com/codex/tasks/task_e_6889a0eba1308320959ce5ba47078900