### PR TITLE
Fix navbar init

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -17,18 +17,17 @@ function renderAppLayout() {
             <div id="pageContent" class="page-content"></div>
         </main>
     `;
-    createSidebar(document.getElementById('sidebar'));
-    createNavbar(document.getElementById('navbar'));
+    // Almacenar las instancias de sidebar y navbar en variables globales
+    window.sidebar = createSidebar(document.getElementById('sidebar'));
+    window.navbar = createNavbar(document.getElementById('navbar'));
 }
 
 // Inicializar la aplicación cuando el DOM esté listo
 document.addEventListener('DOMContentLoaded', () => {
     renderAppLayout();
     // Crear instancias globales usando funciones de creación
-    window.sidebar = createSidebar()
-    window.navbar = createNavbar()
-    window.sectionContent = createSectionContent()
-    window.app = createApp()
+    window.sectionContent = createSectionContent();
+    window.app = createApp();
     window.Utils = Utils
 
     // Exponer métodos útiles globalmente


### PR DESCRIPTION
## Summary
- set up global references for navbar and sidebar when rendering layout
- remove duplicate navbar/sidebar creation

## Testing
- `python3 test_quick.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6889a0e8ec748320bd543e748ad52157