### PR TITLE
feat: add simple frontend for items

### DIFF
--- a/bloque4/funciones.js
+++ b/bloque4/funciones.js
@@ -1,0 +1,125 @@
+const tbody = document.querySelector('#tablaItems tbody');
+const form = document.getElementById('itemForm');
+const mensaje = document.getElementById('mensaje');
+const submitBtn = form.querySelector('button[type="submit"]');
+
+function mostrarMensaje(texto, tipo = 'exito') {
+  mensaje.textContent = texto;
+  mensaje.style.color = tipo === 'error' ? 'red' : 'green';
+}
+
+async function cargarDatos() {
+  try {
+    const res = await fetch('/api/items');
+    if (!res.ok) throw new Error('Error cargando datos');
+    const items = await res.json();
+    pintarTabla(items);
+  } catch (err) {
+    pintarTabla([]);
+    mostrarMensaje(err.message, 'error');
+  }
+}
+
+function pintarTabla(items) {
+  tbody.innerHTML = '';
+  items.forEach(item => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td class="nombre"></td>
+      <td class="descripcion"></td>
+      <td>
+        <button type="button" class="editar">Editar</button>
+        <button type="button" class="eliminar">Eliminar</button>
+      </td>
+    `;
+    tr.querySelector('.nombre').textContent = item.nombre;
+    tr.querySelector('.descripcion').textContent = item.descripcion;
+
+    const btnEditar = tr.querySelector('.editar');
+    const btnEliminar = tr.querySelector('.eliminar');
+
+    btnEliminar.addEventListener('click', async () => {
+      btnEliminar.disabled = true;
+      try {
+        const res = await fetch(`/api/items/${item.id}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error('Error eliminando item');
+        mostrarMensaje('Item eliminado');
+        await cargarDatos();
+      } catch (err) {
+        mostrarMensaje(err.message, 'error');
+      } finally {
+        btnEliminar.disabled = false;
+      }
+    });
+
+    btnEditar.addEventListener('click', () => activarEdicion(tr, item));
+
+    tbody.appendChild(tr);
+  });
+}
+
+function activarEdicion(tr, item) {
+  const nombreCell = tr.querySelector('.nombre');
+  const descripcionCell = tr.querySelector('.descripcion');
+  const accionesCell = tr.lastElementChild;
+
+  nombreCell.innerHTML = `<input type="text" value="${item.nombre}">`;
+  descripcionCell.innerHTML = `<input type="text" value="${item.descripcion}">`;
+  accionesCell.innerHTML = '';
+
+  const btnGuardar = document.createElement('button');
+  btnGuardar.textContent = 'Guardar';
+  const btnCancelar = document.createElement('button');
+  btnCancelar.textContent = 'Cancelar';
+  accionesCell.append(btnGuardar, btnCancelar);
+
+  btnGuardar.addEventListener('click', async () => {
+    btnGuardar.disabled = true;
+    const actualizado = {
+      nombre: nombreCell.firstElementChild.value,
+      descripcion: descripcionCell.firstElementChild.value
+    };
+    try {
+      const res = await fetch(`/api/items/${item.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(actualizado)
+      });
+      if (!res.ok) throw new Error('Error actualizando item');
+      mostrarMensaje('Item actualizado');
+      await cargarDatos();
+    } catch (err) {
+      mostrarMensaje(err.message, 'error');
+    } finally {
+      btnGuardar.disabled = false;
+    }
+  });
+
+  btnCancelar.addEventListener('click', cargarDatos);
+}
+
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  submitBtn.disabled = true;
+  const nuevo = {
+    nombre: form.nombre.value,
+    descripcion: form.descripcion.value
+  };
+  try {
+    const res = await fetch('/api/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(nuevo)
+    });
+    if (!res.ok) throw new Error('Error creando item');
+    form.reset();
+    mostrarMensaje('Item creado');
+    await cargarDatos();
+  } catch (err) {
+    mostrarMensaje(err.message, 'error');
+  } finally {
+    submitBtn.disabled = false;
+  }
+});
+
+window.addEventListener('DOMContentLoaded', cargarDatos);

--- a/bloque4/index.html
+++ b/bloque4/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Bloque 4</title>
+  <style>
+    table, th, td { border: 1px solid #ccc; border-collapse: collapse; }
+    th, td { padding: 0.5rem; }
+    #mensaje { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Gestor de Items</h1>
+  </header>
+
+  <main>
+    <section>
+      <table id="tablaItems">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Descripción</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Agregar Item</h2>
+      <form id="itemForm">
+        <label>Nombre
+          <input type="text" name="nombre" required />
+        </label>
+        <label>Descripción
+          <input type="text" name="descripcion" required />
+        </label>
+        <button type="submit">Guardar</button>
+      </form>
+    </section>
+
+    <div id="mensaje" aria-live="polite"></div>
+  </main>
+
+  <script src="funciones.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Bloque 4 with HTML scaffold and JS functions for CRUD operations
- implement data loading, table rendering, form handling and inline editing

## Testing
- `pytest` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68956cfa490c832084c2ab4f537455a5