### PR TITLE
docs: add bloque 5 setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Configuración de base de datos
+DB_CLIENT=sqlite
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=items_db

--- a/bloque5/README.md
+++ b/bloque5/README.md
@@ -1,0 +1,32 @@
+# Bloque 5 — Puesta en marcha, pruebas y conmutación DB
+
+## SQLite (offline por defecto)
+1. `npm install`
+2. Crear `.env` a partir de `.env.example` con `DB_CLIENT=sqlite`.
+3. `npm run dev` o `npm start` → crea `data.db` si no existe y levanta en `http://localhost:3000`.
+
+## MySQL (opcional)
+1. Crear base de datos y usuario.
+2. Ejecutar `db.sql` para la tabla.
+3. Configurar `.env` con:
+   ```
+   DB_CLIENT=mysql
+   DB_HOST=tu_host
+   DB_USER=tu_usuario
+   DB_PASSWORD=tu_password
+   DB_NAME=tu_base
+   ```
+4. Reiniciar el servidor.
+
+## Pruebas manuales
+1. Ver que cargue la tabla inicial (semilla JSON).
+2. Agregar un registro con el formulario.
+3. Editar un registro.
+4. Eliminar un registro.
+5. Refrescar la página: los cambios persisten (confirmación DB).
+
+## Futuras mejoras (opcionales)
+- Validaciones de negocio.
+- Paginación.
+- Filtros por fecha/categoría.
+- Exportar CSV.

--- a/bloque5/db.sql
+++ b/bloque5/db.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre TEXT,
+  descripcion TEXT
+);


### PR DESCRIPTION
## Summary
- document database setup and switching in new Bloque 5 guide
- provide example environment variables
- include SQL for creating items table on MySQL

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68956e96aa1883209ae417c95a7d12f6